### PR TITLE
chore: upgrade actions/create-github-app-token to v3, use client-id

### DIFF
--- a/.github/workflows/approveops.yml
+++ b/.github/workflows/approveops.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     # get the app's installation token
-    - uses: actions/create-github-app-token@v1
+    - uses: actions/create-github-app-token@v3
       id: app-token
       with:
-        app-id: ${{ vars.APP_ID }}
+        client-id: ${{ vars.APP_CLIENT_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
         
     - name: ApproveOps - ApproveOps in IssueOps


### PR DESCRIPTION
## Summary

Upgrades `actions/create-github-app-token` to `@v3` and migrates from the deprecated `app-id` input to `client-id`.

### Changes
- ⬆️ Updated `actions/create-github-app-token` to `@v3`
- 🔄 Renamed input from `app-id` to `client-id` ([v3 changelog](https://github.com/actions/create-github-app-token/releases/tag/v3.0.0))
- 📝 Renamed variable references to use `*_CLIENT_ID` naming

### ✅ Variable Updates
- New variable(s) created: `APP_CLIENT_ID`
- Workflow updated to reference the new variable(s)

### 🧹 After Merging
Delete the old variable(s) that are no longer referenced: `APP_ID`