### PR TITLE
chore: rename app vars/secrets to GITHUB_APP_* convention

### DIFF
--- a/.github/workflows/approveops.yml
+++ b/.github/workflows/approveops.yml
@@ -14,8 +14,8 @@ jobs:
     - uses: actions/create-github-app-token@v3
       id: app-token
       with:
-        client-id: ${{ vars.APP_CLIENT_ID }}
-        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+        client-id: ${{ vars.GITHUB_APP_CLIENT_ID }}
+        private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
         
     - name: ApproveOps - ApproveOps in IssueOps
       uses: joshjohanning/approveops@v3


### PR DESCRIPTION
## Summary

Renames variable and secret references to match the recommended naming convention from [actions/create-github-app-token](https://github.com/actions/create-github-app-token) docs:

- `vars.APP_CLIENT_ID` → `vars.GITHUB_APP_CLIENT_ID`
- `secrets.PRIVATE_KEY` / `secrets.APP_PRIVATE_KEY` → `secrets.GITHUB_APP_PRIVATE_KEY`

### 🧹 After Merging
- Delete the old `APP_CLIENT_ID` variable (if still present)
- Create/rename the secret from `PRIVATE_KEY`/`APP_PRIVATE_KEY` to `GITHUB_APP_PRIVATE_KEY`